### PR TITLE
Creating easily new decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ LICENSE.txt
 README.txt
 demos/
 extras/documentation
-
+/nbproject/private/
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ LICENSE.txt
 README.txt
 demos/
 extras/documentation
-/nbproject/private/
+/nbproject
 /vendor

--- a/Module.php
+++ b/Module.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace ZfTable;
 
 use ZfTable\Example\Model\CustomerTable;
-
 
 class Module
 {
@@ -19,28 +19,25 @@ class Module
             ),
         );
     }
-    
+
     public function getServiceConfig()
     {
         return array(
             'factories' => array(
-                'ZfTable\Example\Model\CustomerTable' =>  function($sm) {
+                'ZfTable\Example\Model\CustomerTable' => function($sm) {
                     $dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
                     $table = new CustomerTable($dbAdapter);
                     return $table;
                 },
             ),
-           'aliases' => array(
+            'aliases' => array(
                 'zfdb_adapter' => 'Zend\Db\Adapter\Adapter',
             ),
         );
-    }    
-    
+    }
+
     public function getConfig()
     {
         return include __DIR__ . '/config/module.config.php';
     }
-    
-    
-
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -36,11 +36,7 @@ return array(
                 'css/bootstrap-2.2.2/bootstrap.min.css' => __DIR__ . '/../src/ZfTable/Public/css/bootstrap-2.2.2/bootstrap.min.css',
                 'css/bootstrap-2.2.2/bootstrap-responsive.min.css' => __DIR__ . '/../src/ZfTable/Public/css/bootstrap-2.2.2/bootstrap-responsive.min.css',
                 'css/bootstrap-2.2.2/DT_bootstrap.css' => __DIR__ . '/../src/ZfTable/Public/css/bootstrap-2.2.2/DT_bootstrap.css',
-                
             ),
-            
-            
-            
         ),
     ),
     
@@ -55,7 +51,15 @@ return array(
         ),
     ),
     'service_manager' => array(
-        
+        'invokables' => array(
+            'ZfTable\Decorator\DecoratorFactory' => 'ZfTable\Decorator\DecoratorFactory',
+        ),
+        'factories' => array(
+            'ZfTable\Decorator\DecoratorPluginManager' => 'ZfTable\Decorator\Service\DecoratorPluginManagerFactory',
+        ),
+         'abstract_factories' => [
+            'ZfTable\Table\TableAbstractServiceFactory',
+        ],
     ),
     
     // The following section is new and should be added to your file
@@ -92,7 +96,5 @@ return array(
             )
         )
     )
-
-    
 );
 

--- a/src/ZfTable/AbstractTable.php
+++ b/src/ZfTable/AbstractTable.php
@@ -97,6 +97,17 @@ abstract class AbstractTable extends AbstractElement implements TableInterface, 
     protected $options = null;
     
     /**
+     * @var TableForm
+     */
+    protected $form;
+    
+    /**
+     *
+     * @var TableFilter
+     */
+    protected $filter;
+
+    /**
      * @var ServiceLocatorInterface 
      */
     protected $serviceLocator;
@@ -477,7 +488,10 @@ abstract class AbstractTable extends AbstractElement implements TableInterface, 
      */
     public function getForm()
     {
-        return new TableForm(array_keys($this->headers));
+        if (!$this->form) {
+            $this->form = new TableForm(array_keys($this->headers));
+        }
+        return $this->form;
     }
 
     /**
@@ -486,6 +500,10 @@ abstract class AbstractTable extends AbstractElement implements TableInterface, 
      */
     public function getFilter()
     {
-        return new TableFilter(array_keys($this->headers));
+        if (!$this->filter) {
+            $this->filter = new TableFilter(array_keys($this->headers));
+        }
+        return $this->filter;
     }
+    
 }

--- a/src/ZfTable/AbstractTable.php
+++ b/src/ZfTable/AbstractTable.php
@@ -17,7 +17,10 @@ use ZfTable\Options\ModuleOptions;
 use ZfTable\Form\TableForm;
 use ZfTable\Form\TableFilter;
 
-abstract class AbstractTable extends AbstractElement implements TableInterface
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+abstract class AbstractTable extends AbstractElement implements TableInterface, ServiceLocatorAwareInterface
 {
 
     /**
@@ -75,7 +78,6 @@ abstract class AbstractTable extends AbstractElement implements TableInterface
      */
     private $tableInit = false;
 
-
     /**
      * Default classes for table
      * @var array
@@ -88,13 +90,50 @@ abstract class AbstractTable extends AbstractElement implements TableInterface
      */
     protected $config;
 
-
     /**
      * Options base ond ModuleOptions and config array
      * @var Options\ModuleOptions
      */
     protected $options = null;
+    
+    /**
+     * @var ServiceLocatorInterface 
+     */
+    protected $serviceLocator;
+    
+    /**
+     * @var Decorator\DecoratorFactory 
+     */
+    protected $decoratorFactory;
+    
+    /**
+     * @return \Zend\ServiceManager\ServiceLocatorInterface 
+     */
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
+    }
 
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+    
+    /**
+     * @return Decorator\DecoratorFactory
+     */
+    public function getDecoratorFactory()
+    {
+        if (!$this->decoratorFactory) {
+            // check if serviceLocator was loaded if so, try to get the service
+            if ($this->getServiceLocator() && $this->getServiceLocator()->has('ZfTable\Decorator\DecoratorFactory')) {
+                $this->decoratorFactory = $this->getServiceLocator()->get('ZfTable\Decorator\DecoratorFactory');
+            } else {
+                $this->decoratorFactory = new Decorator\DecoratorFactory();
+            }
+        }
+        return $this->decoratorFactory;
+    }
 
     /**
      * Check if table has benn initializable
@@ -133,8 +172,6 @@ abstract class AbstractTable extends AbstractElement implements TableInterface
     {
         return $this->paramAdapter;
     }
-
-
 
     /**
      *
@@ -296,7 +333,7 @@ abstract class AbstractTable extends AbstractElement implements TableInterface
      */
     protected function initQuickSearch()
     {
-
+        
     }
 
     /**
@@ -305,7 +342,7 @@ abstract class AbstractTable extends AbstractElement implements TableInterface
      */
     protected function initFilters($query)
     {
-
+        
     }
 
     /**

--- a/src/ZfTable/Cell.php
+++ b/src/ZfTable/Cell.php
@@ -3,13 +3,12 @@
  * ZfTable ( Module for Zend Framework 2)
  *
  * @copyright Copyright (c) 2013 Piotr Duda dudapiotrek@gmail.com
- * @license   MIT License
+ * @license   MIT License 
  */
 
 namespace ZfTable;
 
 use ZfTable\AbstractElement;
-use ZfTable\Decorator\DecoratorFactory;
 
 class Cell extends AbstractElement
 {
@@ -19,9 +18,9 @@ class Cell extends AbstractElement
      * @var Header
      */
     protected $header;
-
+    
     /**
-     *
+     * 
      * @param Header $header
      */
     public function __construct($header)
@@ -30,19 +29,28 @@ class Cell extends AbstractElement
     }
 
     /**
-     *
+     * 
      * @param string $name type
      * @param array  $options type
      * @return Decorator\AbstractDecorator
      */
     public function addDecorator($name, $options = array())
     {
-        $decorator = DecoratorFactory::factoryCell($name, $options);
+        $decorator = $this->getDecoratorFactory()->factoryCell($name, $options);
         $decorator->setCell($this);
         $this->attachDecorator($decorator);
         return $decorator;
     }
 
+    /**
+     * @return Decorator\DecoratorFactory
+     */
+    protected function getDecoratorFactory()
+    {
+        return $this->table->getDecoratorFactory();
+    }
+
+    
     /**
      * Get header object
      * @return Header
@@ -65,7 +73,7 @@ class Cell extends AbstractElement
     }
 
     /**
-     * Get actual row
+     * Get actual row 
      *
      * @return array
      */
@@ -82,7 +90,7 @@ class Cell extends AbstractElement
     public function render($type = 'html')
     {
         $row = $this->getTable()->getRow()->getActualRow();
-
+        
         $value = '';
 
         if (is_array($row) || $row instanceof \ArrayAccess) {
@@ -90,13 +98,13 @@ class Cell extends AbstractElement
         } elseif (is_object($row)) {
             $headerName = $this->getHeader()->getName();
             $methodName = 'get' . ucfirst($headerName);
-            if (method_exists($row, $methodName)) {
-                $value = $row->$methodName();
-            } else {
-                $value = (property_exists($row, $headerName)) ? $row->$headerName : '';
-            }
+			if (method_exists($row, $methodName)) {
+				$value = $row->$methodName();
+			} else {
+				$value = (property_exists($row, $headerName)) ? $row->$headerName : '';
+			}
         }
-
+        
         foreach ($this->decorators as $decorator) {
             if ($decorator->validConditions()) {
                 $value = $decorator->render($value);
@@ -107,7 +115,7 @@ class Cell extends AbstractElement
             $ret = sprintf("<td %s>%s</td>", $this->getAttributes(), $value);
             $this->clearVar();
             return $ret;
-
+            
         } else {
             return $value;
         }

--- a/src/ZfTable/Decorator/DecoratorFactory.php
+++ b/src/ZfTable/Decorator/DecoratorFactory.php
@@ -3,71 +3,101 @@
  * ZfTable ( Module for Zend Framework 2)
  *
  * @copyright Copyright (c) 2013 Piotr Duda dudapiotrek@gmail.com
- * @license   MIT License
+ * @license   MIT License 
  */
 
 namespace ZfTable\Decorator;
 
-class DecoratorFactory
-{
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
+class DecoratorFactory implements ServiceLocatorAwareInterface
+{
+    CONST CELL_PREFIX = 'cell';
+    CONST HEADER_PREFIX = 'header';
+    CONST ROW_PREFIX = 'row';  
+    
     /**
      * The decorator manger
      *
      * @var null|DecoratorPluginManager
      */
-    protected static $decoratorManager = null;
-
-    const CELL_PREFIX = 'cell';
-    const HEADER_PREFIX = 'header';
-    const ROW_PREFIX = 'row';
-
+    protected $decoratorManager = null;
+    
     /**
-     *
+     * @var ServiceLocatorInterface 
+     */
+    protected $serviceLocator;
+    
+    /**
+     * 
      * @param string $name
      * @param array $options
      * @return AbstractDecorator
      */
-    public static function factoryCell($name, $options)
+    public function factoryCell($name, $options)
     {
-        $decorator = static::getPluginManager()->get(self::CELL_PREFIX . $name, $options);
+        $decorator = $this->getPluginManager()->get(self::CELL_PREFIX . $name, $options);
         return $decorator;
     }
 
     /**
-     *
+     * 
      * @param string $name
      * @param array $options
      * @return AbstractDecorator
      */
-    public static function factoryRow($name, $options)
+    public function factoryRow($name, $options)
     {
-        $decorator = static::getPluginManager()->get(self::ROW_PREFIX . $name, $options);
+        $decorator = $this->getPluginManager()->get(self::ROW_PREFIX . $name, $options);
         return $decorator;
     }
 
     /**
-     *
+     * 
      * @param string $name
      * @param array $options
      * @return AbstractDecorator
      */
-    public static function factoryHeader($name, $options)
+    public function factoryHeader($name, $options)
     {
-        $decorator = static::getPluginManager()->get(self::HEADER_PREFIX . $name, $options);
+        $decorator = $this->getPluginManager()->get(self::HEADER_PREFIX . $name, $options);
         return $decorator;
     }
 
     /**
      * Get the pattern plugin manager
-     *
+     *  
      * @return DecoratorPluginManager
      */
-    public static function getPluginManager()
+    public function getPluginManager()
     {
-        if (static::$decoratorManager === null) {
-            static::$decoratorManager = new DecoratorPluginManager();
+        if ($this->decoratorManager === null) {
+            if($this->getServiceLocator() && $this->getServiceLocator()->has('ZfTable\Decorator\DecoratorPluginManager')) {
+                $this->decoratorManager = $this->getServiceLocator()->get('ZfTable\Decorator\DecoratorPluginManager');
+            }
+            else {
+                $this->decoratorManager = new DecoratorPluginManager();
+            }
         }
-        return static::$decoratorManager;
+        return $this->decoratorManager;
+    }
+
+    public function setPluginManager(DecoratorPluginManager $decoratorManager)
+    {
+        $this->decoratorManager = $decoratorManager;
+    }
+    
+    /**
+     * @return ServiceLocatorInterface 
+     */
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
+    }
+
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
     }
 }

--- a/src/ZfTable/Decorator/DecoratorPluginManager.php
+++ b/src/ZfTable/Decorator/DecoratorPluginManager.php
@@ -30,7 +30,6 @@ class DecoratorPluginManager extends AbstractPluginManager
         'celleditable' => '\ZfTable\Decorator\Cell\Editable',
         'cellcallable' => '\ZfTable\Decorator\Cell\CallableDecorator',
 
-
         'rowclass' => '\ZfTable\Decorator\Row\ClassDecorator',
         'rowvarattr' => '\ZfTable\Decorator\Row\VarAttr',
         'rowseparatable' => '\ZfTable\Decorator\Row\Separatable',

--- a/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
+++ b/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * ZfTable ( Module for Zend Framework 2)
+ *
+ * @copyright Copyright (c) 2013 Piotr Duda dudapiotrek@gmail.com
+ * @license   MIT License 
+ */
+
+namespace ZfTable\Decorator\Service;
+
+use Zend\Mvc\Service\AbstractPluginManagerFactory;
+
+class DecoratorPluginManagerFactory  extends AbstractPluginManagerFactory
+{
+    const PLUGIN_MANAGER_CLASS = 'ZfTable\Decorator\DecoratorPluginManager';
+}

--- a/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
+++ b/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
@@ -10,7 +10,9 @@
 namespace ZfTable\Decorator\Service;
 
 use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\Config as ConfigServiceMgr;
+use ZfTable\Decorator\DecoratorPluginManager;
 
 class DecoratorPluginManagerFactory implements FactoryInterface
 {
@@ -20,10 +22,9 @@ class DecoratorPluginManagerFactory implements FactoryInterface
         $configuration   = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
         $configSeviceMgr = new ConfigServiceMgr(isset($configuration['zftable_decorators'])? : array());
 
-        $plugins = new ZfTable\Decorator\DecoratorPluginManager($configSeviceMgr);
+        $plugins = new DecoratorPluginManager($configSeviceMgr);
         $plugins->setServiceLocator($serviceLocator);
 
-        $configuration = $serviceLocator->get('Config');
         if (isset($configuration['di']) && $serviceLocator->has('Di')) {
             $plugins->addAbstractFactory($serviceLocator->get('DiAbstractServiceFactory'));
         }

--- a/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
+++ b/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ZfTable ( Module for Zend Framework 2)
  *
@@ -8,9 +9,26 @@
 
 namespace ZfTable\Decorator\Service;
 
-use Zend\Mvc\Service\AbstractPluginManagerFactory;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\Config as ConfigServiceMgr;
 
-class DecoratorPluginManagerFactory  extends AbstractPluginManagerFactory
+class DecoratorPluginManagerFactory implements FactoryInterface
 {
-    const PLUGIN_MANAGER_CLASS = 'ZfTable\Decorator\DecoratorPluginManager';
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $configuration   = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
+        $configSeviceMgr = new ConfigServiceMgr(isset($configuration['zftable_decorators'])? : array());
+
+        $plugins = new ZfTable\Decorator\DecoratorPluginManager($configSeviceMgr);
+        $plugins->setServiceLocator($serviceLocator);
+
+        $configuration = $serviceLocator->get('Config');
+        if (isset($configuration['di']) && $serviceLocator->has('Di')) {
+            $plugins->addAbstractFactory($serviceLocator->get('DiAbstractServiceFactory'));
+        }
+
+        return $plugins;
+    }
+
 }

--- a/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
+++ b/src/ZfTable/Decorator/Service/DecoratorPluginManagerFactory.php
@@ -19,13 +19,13 @@ class DecoratorPluginManagerFactory implements FactoryInterface
 
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $configuration   = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
-        $configSeviceMgr = new ConfigServiceMgr(isset($configuration['zftable_decorators'])? : array());
+        $config       = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
+        $configSevice = new ConfigServiceMgr(isset($config['zftable_decorators']) ? $config['zftable_decorators'] : array());
 
-        $plugins = new DecoratorPluginManager($configSeviceMgr);
+        $plugins = new DecoratorPluginManager($configSevice);
         $plugins->setServiceLocator($serviceLocator);
 
-        if (isset($configuration['di']) && $serviceLocator->has('Di')) {
+        if (isset($config['di']) && $serviceLocator->has('Di')) {
             $plugins->addAbstractFactory($serviceLocator->get('DiAbstractServiceFactory'));
         }
 

--- a/src/ZfTable/Header.php
+++ b/src/ZfTable/Header.php
@@ -3,14 +3,13 @@
  * ZfTable ( Module for Zend Framework 2)
  *
  * @copyright Copyright (c) 2013 Piotr Duda dudapiotrek@gmail.com
- * @license   MIT License
+ * @license   MIT License 
  */
 
 namespace ZfTable;
 
 use ZfTable\AbstractElement;
 use ZfTable\Cell;
-use ZfTable\Decorator\DecoratorFactory;
 
 class Header extends AbstractElement
 {
@@ -20,64 +19,64 @@ class Header extends AbstractElement
      * @var string
      */
     protected $name;
-
+    
     /**
      * Title of header
      *
      * @var string
      */
     protected $title;
-
+    
     /**
      * Width of the column
      *
      * @var int
      */
     protected $width;
-
-
+    
+    
     /**
      * Name of table alias for defined column
      *
      * @var string
      */
     protected $tableAlias;
-
+    
     /**
      * Cell object
      * @var Cell
      */
     protected $cell;
-
+    
     /**
      * Flag to inform if column should be sortable
      *
-     * @var boolean
+     * @var boolean 
      */
     protected $sortable = true;
-
+    
     /**
      * Check if column is separatable
      *
      * @var boolean
      */
     protected $separatable = false;
-
+    
     /**
      * Check if column is editable
      *
      * @var boolean
      */
     protected $editable = false;
-
-
+    
+    
     /**
      * Table of options
      *
      * @var array
      */
     protected $options = array();
-
+    
     /**
      * Static array exchanging ordering (when column is ascending, in data-ordering should be desc)
      *
@@ -87,7 +86,7 @@ class Header extends AbstractElement
         'asc' => 'desc',
         'desc' => 'asc'
     );
-
+    
     /**
      * Array of options
      *
@@ -110,12 +109,20 @@ class Header extends AbstractElement
      */
     public function addDecorator($name, $options = array())
     {
-        $decorator = DecoratorFactory::factoryHeader($name, $options);
+        $decorator = $this->getDecoratorFactory()->factoryHeader($name, $options);
         $this->attachDecorator($decorator);
         $decorator->setHeader($this);
         return $decorator;
     }
 
+    /**
+     * @return Decorator\DecoratorFactory
+     */
+    protected function getDecoratorFactory()
+    {
+        return $this->table->getDecoratorFactory();
+    }
+    
     /**
      * Set options like title, width, order
      *
@@ -130,16 +137,15 @@ class Header extends AbstractElement
         $this->sortable = (isset($options['sortable'])) ? $options['sortable'] : true;
         $this->separatable = (isset($options['separatable'])) ? $options['separatable'] : $this->getSeparatable();
         $this->tableAlias = (isset($options['tableAlias'])) ? $options['tableAlias'] : '';
-
+        
         if (isset($options['editable']) && $options['editable'] == true) {
             $this->editable = $options['editable'];
             $this->getCell()->addDecorator('editable', array());
         }
-
-
+        
         return $this;
     }
-
+    
     /**
      * Get width of column
      *
@@ -181,7 +187,7 @@ class Header extends AbstractElement
     }
 
     /**
-     * Set name of header
+     * Set name of header 
      *
      * @param string $name
      * @return $this
@@ -223,7 +229,7 @@ class Header extends AbstractElement
     {
         return $this->title;
     }
-
+    
     /**
      * Get sortable flag
      *
@@ -243,7 +249,7 @@ class Header extends AbstractElement
     {
         $this->sortable = $sortable;
     }
-
+    
     /**
      * Get flat to inform about separable
      *
@@ -263,16 +269,16 @@ class Header extends AbstractElement
     {
         $this->separatable = $separatable;
     }
-
+    
     /**
-     *
+     * 
      * @return boolean
      */
     public function getEditable()
     {
         return $this->editable;
     }
-
+    
     /**
      * Flag to inform about for all cell in header
      *
@@ -302,7 +308,7 @@ class Header extends AbstractElement
     {
         return $this->tableAlias;
     }
-
+    
     /**
      * Set reference to table
      *
@@ -323,7 +329,7 @@ class Header extends AbstractElement
         $paramColumn = $this->getTable()->getParamAdapter()->getColumn();
         $paramOrder = $this->getTable()->getParamAdapter()->getOrder();
         $order = ($paramColumn == $this->getName()) ? self::$orderReverse[$paramOrder] : 'asc';
-
+        
         if ($this->getSortable()) {
             $classSorting = ($paramColumn == $this->getName())
                 ? 'sorting_' . self::$orderReverse[$paramOrder] : 'sorting';
@@ -332,13 +338,12 @@ class Header extends AbstractElement
             $this->addAttr('data-order', $order);
             $this->addAttr('data-column', $this->getName());
         }
-
-
+        
         if ($this->width) {
             $this->addAttr('width', $this->width);
         }
     }
-
+    
     /**
      * Rendering header element
      *
@@ -348,7 +353,7 @@ class Header extends AbstractElement
     {
         $this->initRendering();
         $render = $this->getTitle();
-
+        
         foreach ($this->decorators as $decorator) {
             $render = $decorator->render($render);
         }

--- a/src/ZfTable/Row.php
+++ b/src/ZfTable/Row.php
@@ -3,28 +3,27 @@
  * ZfTable ( Module for Zend Framework 2)
  *
  * @copyright Copyright (c) 2013 Piotr Duda dudapiotrek@gmail.com
- * @license   MIT License
+ * @license   MIT License 
  */
 
 namespace ZfTable;
 
 use ZfTable\AbstractElement;
-use ZfTable\Decorator\DecoratorFactory;
 use ZfTable\Table\Exception;
 
 class Row extends AbstractElement
 {
     protected $class = array('zf-data-row');
-
+    
     /**
-     *
+     * 
      * @var array
      */
     protected $actualRow;
 
-
+    
     /**
-     *
+     * 
      * @param AbstractTable $table
      */
     public function __construct($table)
@@ -33,22 +32,29 @@ class Row extends AbstractElement
     }
 
     /**
-     *
+     * 
      * @param string $name
      * @param array $options
      * @return Decorator\Header\AbstractHeaderDecorator
      */
     public function addDecorator($name, $options = array())
     {
-        $decorator = DecoratorFactory::factoryRow($name, $options);
+        $decorator = $this->getDecoratorFactory()->factoryRow($name, $options);
         $this->attachDecorator($decorator);
         $decorator->setRow($this);
         return $decorator;
     }
+    
+    /**
+     * @return Decorator\DecoratorFactory
+     */
+    protected function getDecoratorFactory()
+    {
+        return $this->table->getDecoratorFactory();
+    }
 
     /**
-     * Get actual row
-     *
+     * Get actaul row 
      * @return array
      */
     public function getActualRow()
@@ -57,7 +63,7 @@ class Row extends AbstractElement
     }
 
     /**
-     *
+     * 
      * @param array $actualRow
      */
     public function setActualRow($actualRow)
@@ -65,7 +71,7 @@ class Row extends AbstractElement
         $this->actualRow = $actualRow;
     }
 
-
+    
     /**
      * Rendering all rows for table
      *
@@ -83,7 +89,7 @@ class Row extends AbstractElement
         } else {
             throw new Exception\InvalidArgumentException();
         }
-
+        
     }
 
     /**
@@ -97,7 +103,7 @@ class Row extends AbstractElement
         $data = $this->getTable()->getData();
         $headers = $this->getTable()->getHeaders();
         $render = array();
-
+        
         foreach ($data as $rowData) {
             $this->setActualRow($rowData);
             $temp = array();
@@ -105,14 +111,14 @@ class Row extends AbstractElement
                 if ($type == 'assc') {
                     $temp[$name] =  $this->getTable()->getHeader($name)->getCell()->render('array');
                 } else {
-                    $temp[] =  $this->getTable()->getHeader($name)->getCell()->render('array');
+                     $temp[] =  $this->getTable()->getHeader($name)->getCell()->render('array');
                 }
             }
             $render[] = $temp;
         }
         return $render;
     }
-
+    
     /**
      * rendering row as a html
      *
@@ -123,7 +129,7 @@ class Row extends AbstractElement
         $data = $this->getTable()->getData();
         $headers = $this->getTable()->getHeaders();
         $render = '';
-
+        
         foreach ($data as $rowData) {
             $this->setActualRow($rowData);
             $rowRender = '';

--- a/src/ZfTable/Table/TableAbstractServiceFactory.php
+++ b/src/ZfTable/Table/TableAbstractServiceFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * ZfTable ( Module for Zend Framework 2)
+ *
+ * @copyright Copyright (c) 2013 Piotr Duda dudapiotrek@gmail.com
+ * @license   MIT License
+ */
+
+namespace ZfTable\Table;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+
+/**
+ * Can creates any children from AbstractTable, invokes a new instance, but 
+ * injects the main service locator object into it. 
+ */
+class TableAbstractServiceFactory implements AbstractFactoryInterface
+{
+
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if (class_exists($requestedName)) {
+            $reflect = new \ReflectionClass($requestedName);
+            if ($reflect->isSubclassOf('ZfTable\AbstractTable')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ($this->canCreateServiceWithName($serviceLocator, $name, $requestedName)) {
+            return new $requestedName;
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
I have created some services and from now on we can create FactoryDecorator, DecoratorPluginManager and any child of AbstractTable using the main ServiceLocator.

I have made theses changes because now we can create and register new Decorators, using the key 'zftable_decorators' on config, even factories, abstract_factories or of course invokables.

[Config file real example](https://github.com/fagundes/zff-base/blob/develop/config/module.config.php#L74)

[My question on the main repository](https://github.com/dudapiotr/ZfTable/issues/85)

What do you think about these changes?
Should I pull request for another branch?
